### PR TITLE
Assign resp explicitly.

### DIFF
--- a/lib/net/ntlm_http.rb
+++ b/lib/net/ntlm_http.rb
@@ -50,7 +50,7 @@ module Net  #:nodoc:
 
     def request req, body=nil, &block
       resp = data = auth_data = nil
-      old_request req, body do |resp|
+      resp = old_request req, body do |resp|
         wwwauth = resp.header['www-authenticate'].split(",").collect{|x| x.strip} rescue ""
         unless Net::HTTPUnauthorized === resp and auth_data = req.auth_data and
             auth_data[0] == :ntlm and (wwwauth == 'NTLM' || wwwauth.is_a?(Array) && wwwauth.include?('NTLM')) ||


### PR DESCRIPTION
I came across this bug while fixing:

https://github.com/rubiii/httpi/issues#issue/25

Long story short, your monkey-patched #request blows up in Ruby 1.9.2. Check this out for explanation:

http://twitter.com/#!/hakanensari/status/54909075913322498

Also, a heads up: Your test doesn't work under 1.9.2.
