### PR TITLE
fix UTF16 BOM removal problem on ruby 1.9.2

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ require File.join(File.dirname(__FILE__), 'lib', 'net', 'ntlm')
 
 #PKG_NAME = 'rubyntlm'
 PKG_NAME = 'pyu-ntlm-http'
-PKG_VERSION = "0.1.3.1"
+PKG_VERSION = "0.1.3.2"
 
 task :default => [:test]
 

--- a/lib/net/ntlm.rb
+++ b/lib/net/ntlm.rb
@@ -100,8 +100,12 @@ module Net  #:nodoc:
       end
 
       def encode_utf16le(str)
-        # Kconv on JRUBY outputs a BOM... so strip that
-        swap16(Kconv.kconv(str, Kconv::UTF16, Kconv::ASCII).gsub(/^\376\377/,''))
+        if str.respond_to?(:encode) # ruby 1.9 / jruby --1.9
+          str.encode("UTF-16LE").force_encoding("ASCII-8BIT")
+        else
+          # Kconv on JRUBY outputs a BOM... so strip that
+          swap16(Kconv.kconv(str, Kconv::UTF16, Kconv::ASCII).gsub(/^\376\377/,''))
+        end
       end
     
       def pack_int64le(val)


### PR DESCRIPTION
hi ping,

here's a fix for the problem with the BOM removal regexp on ruby 1.9.2

it's tested on both

ruby-1.9.2-p180 [ x86_64 ]
ruby-1.8.7-p334 [ x86_64 ]

against an Exchange 2010 SP1 server with NTLM authentication

it seems there are further problems with the ntlm_http.rb on ruby 1.9.2, but i authenticated fine using latest httpclient and 'net/ntlm' portion of pyu-ntlm-http gem, so i will raise another bug for the other problems
