### PR TITLE
Updated for jruby and ruby 2.0 support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,10 @@
 # Rakefile for rubyntlm    -*- ruby -*-
 # $Id: Rakefile,v 1.2 2006/10/05 01:36:52 koheik Exp $
 
-require 'rake/rdoctask'
+require 'rdoc/task'
 require 'rake/testtask'
 require 'rake/packagetask'
-require 'rake/gempackagetask'
+require 'rubygems/package_task'
 require File.join(File.dirname(__FILE__), 'lib', 'net', 'ntlm')
 
 #PKG_NAME = 'rubyntlm'
@@ -57,7 +57,7 @@ spec = Gem::Specification.new do |s|
   s.autorequire = 'net/ntlm_http'
 end
 
-Rake::GemPackageTask.new(spec) do |p|
+Gem::PackageTask.new(spec) do |p|
   p.gem_spec = spec
   p.need_tar = true
   p.need_zip = true

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ require File.join(File.dirname(__FILE__), 'lib', 'net', 'ntlm')
 
 #PKG_NAME = 'rubyntlm'
 PKG_NAME = 'pyu-ntlm-http'
-PKG_VERSION = "0.1.3.1"
+PKG_VERSION = "0.1.3.2"
 
 task :default => [:test]
 

--- a/lib/net/ntlm.rb
+++ b/lib/net/ntlm.rb
@@ -100,8 +100,12 @@ module Net  #:nodoc:
       end
 
       def encode_utf16le(str)
-        # Kconv on JRUBY outputs a BOM... so strip that
-        swap16(Kconv.kconv(str, Kconv::UTF16, Kconv::ASCII).gsub(/^\376\377/,''))
+        if str.respond_to?(:encode) # ruby 1.9 / jruby --1.9
+          str.encode("UTF-16LE").force_encoding("ASCII-8BIT")
+        else
+          # Kconv on JRUBY outputs a BOM... so strip that
+          swap16(Kconv.kconv(str, Kconv::UTF16, Kconv::ASCII).gsub(/^\376\377/,''))
+        end
       end
     
       def pack_int64le(val)

--- a/lib/net/ntlm.rb
+++ b/lib/net/ntlm.rb
@@ -1,4 +1,4 @@
-#
+# encoding: us-ascii
 # = net/ntlm.rb
 #
 # An NTLM Authentication Library for Ruby
@@ -45,6 +45,7 @@
 require 'base64'
 require 'openssl'
 require 'openssl/digest'
+require 'kconv'
 
 module Net  #:nodoc:
   module NTLM

--- a/ntlm-http.gemspec
+++ b/ntlm-http.gemspec
@@ -1,0 +1,22 @@
+# -*- encoding: utf-8 -*-
+
+Gem::Specification.new do |s|
+  s.name        = "pyu-ntlm-http"
+  s.version     = "0.1.3.2"
+  s.authors     = ["Kohei Kajimoto", "Kingsley Hendrickse"]
+  s.email       = ["kingsley@mindflowsolutions.com"]
+  s.homepage    = ""
+  s.summary = %q{Ruby/NTLM HTTP library.}
+  s.description = %q{Ruby/NTLM HTTP provides NTLM authentication over http.}
+
+  s.rubyforge_project = "my_gem"
+
+  s.files         = `git ls-files`.split("\n")
+  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.require_paths = ["lib"]
+
+  # specify any dependencies here; for example:
+  # s.add_development_dependency "rspec"
+  # s.add_runtime_dependency "rest-client"
+end

--- a/ntlm-http.gemspec
+++ b/ntlm-http.gemspec
@@ -1,10 +1,10 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |s|
-  s.name        = "pyu-ntlm-http"
+  s.name        = "ntlm-http"
   s.version     = "0.1.3.3"
-  s.authors     = ["Kohei Kajimoto", "Kingsley Hendrickse"]
-  s.email       = ["kingsley@mindflowsolutions.com"]
+  s.authors     = ["Kohei Kajimoto", "Kingsley Hendrickse", "Michael Ries"]
+  s.email       = ["kingsley@mindflowsolutions.com","michael@riesd.com"]
   s.homepage    = ""
   s.summary = %q{Ruby/NTLM HTTP library.}
   s.description = %q{Ruby/NTLM HTTP provides NTLM authentication over http.}

--- a/ntlm-http.gemspec
+++ b/ntlm-http.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "pyu-ntlm-http"
-  s.version     = "0.1.3.2"
+  s.version     = "0.1.3.3"
   s.authors     = ["Kohei Kajimoto", "Kingsley Hendrickse"]
   s.email       = ["kingsley@mindflowsolutions.com"]
   s.homepage    = ""


### PR DESCRIPTION
I have been using a personal fork of this project for about 4 months at work.  This fork is based of of lxcid/ntlm-http I added a few more fixes so that it works in ruby-2.0.0-p0. I also updated the Rakefile so that the tests can actually run now.  

All tests are passing and I have tested it on jruby-1.7.2, jruby-1.7.3, ruby-1.9.3 and ruby-2.0.0-p0.
